### PR TITLE
add default wrap prop

### DIFF
--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -88,4 +88,19 @@ describe('React Anaconda', () => {
       });
     });
   });
+
+  describe('When the wrap prop is omitted', () => {
+    it('Its children should be rendered without being wrapped', () => {
+      const wrapper = shallow(
+        <Anaconda
+          when={true}
+        >
+          <span />
+        </Anaconda>
+      );
+
+      expect(wrapper.find('span').exists()).toEqual(true);
+    });
+  });
+  
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export default ({ when, wrap = (children) => children, children, ...rest }) => {
+const defaultWrap = (children) => children;
+
+export default ({ when, wrap = defaultWrap, children, ...rest }) => {
   const Container = React.Fragment || React.createElement('div');
 
   return (

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default ({ when, wrap, children, ...rest }) => {
+export default ({ when, wrap = (children) => children, children, ...rest }) => {
   const Container = React.Fragment || React.createElement('div');
 
   return (


### PR DESCRIPTION
Adds a default wrap prop which lets the wrapping component be rendered if `wrap` has not been provided.