### PR TITLE
fix cloning props when wrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ class BasicBooleanExample extends Component {
   }
 }
 
-ReactDOM.render(<BasicBooleanExample />, document.querySelector('.foo'));
+ReactDOM.render(<BasicBooleanExample clickable />, document.querySelector('.foo'));
 ```
 
 #### Rendered Markup
@@ -127,7 +127,8 @@ class MapBooleanExample extends Component {
 }
 
 ReactDOM.render(
-<MapBooleanExample 
+<MapBooleanExample
+  clickable
   linkNames={[
     'Click me!',
     'And me!',
@@ -235,7 +236,7 @@ class PropShareExample extends Component {
   render() {
     return (
       <Anaconda
-        when={this.props.clickable}
+        when={(props) => props.clickable}
         wrap={(children) => <a href="http://cool-url.com">{children}</a>}
         name="foo"
         bar={5}

--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -103,4 +103,32 @@ describe('React Anaconda', () => {
     });
   });
   
+  describe('When a child is wrapped and extra props are supplied', () => {
+    it('Its children should be passed the extra props instead of the wrapped element', () => {
+
+      const NameBar = ({ name, bar }) => <span>{name}:{bar}</span>;
+
+      const BarName = ({ name, bar }) => <span>{bar}:{name}</span>;
+
+      const wrapper = shallow(
+        <Anaconda
+          when={(props) => props.clickable}
+          wrap={(children) => <a href="http://cool-url.com">{children}</a>}
+          name="foo"
+          bar={5}
+      > 
+        <NameBar clickable />
+        <BarName />
+      </Anaconda>
+      );
+
+      expect(wrapper.find(NameBar).exists()).toEqual(true);
+      expect(wrapper.find(NameBar).props()).toEqual({ clickable: true, name: "foo", bar: 5 });
+
+      expect(wrapper.find(BarName).exists()).toEqual(true);
+      expect(wrapper.find(BarName).props()).toEqual({ name: "foo", bar: 5 });
+
+    });
+  });
+  
 });

--- a/src/index.js
+++ b/src/index.js
@@ -8,11 +8,19 @@ export default ({ when, wrap = defaultWrap, children, ...rest }) => {
   return (
     <Container>
       {React.Children.map(children, child => {
+
         if (
           typeof when === 'function' && when(child.props) ||
           when === true
         ) {
+
+          if (rest) {
+            child = React.cloneElement(child, rest);
+          }
+
           child = wrap(child, child.props);
+
+          return child;
         }
         return rest ? React.cloneElement(child, rest) : child;
       })}


### PR DESCRIPTION
Fixes an issue that when a child is being wrapped. 

Due to the wrapping element not being a React class or component. The props are being added as attributes onto the wrapping element and not its children. 

